### PR TITLE
feat: 게시글 검색 기능 개발

### DIFF
--- a/src/api/saving.ts
+++ b/src/api/saving.ts
@@ -1,6 +1,6 @@
 import axios from './defaultClient';
 
-export const getBuyingPostList = () => {
+export const getBuyingPostList = (keyword?: string) => {
   return axios.get('/saving/buy-together', {
     params: {
       // page: 0,
@@ -10,6 +10,7 @@ export const getBuyingPostList = () => {
       // lat: 0,
       // lng: 0,
       // distance: 0,
+      keyword,
     },
   });
 };
@@ -28,7 +29,7 @@ export const getBuyingPost = (id: string | undefined) => {
   });
 };
 
-export const getKnowingPostList = () => {
+export const getKnowingPostList = (keyword?: string) => {
   return axios.get('/saving/know-together', {
     params: {
       // page: 0,
@@ -38,6 +39,7 @@ export const getKnowingPostList = () => {
       // lat: 0,
       // lng: 0,
       // distance: 0,
+      keyword,
     },
   });
 };

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,11 +1,58 @@
-import React from 'react';
+import React, { KeyboardEvent, useState } from 'react';
 import styled from 'styled-components';
 import SearchIcon from '@mui/icons-material/Search';
 
+import { useAppDispatch, useAppSelector } from '../hooks/redux';
+import { fetchBuyingPostList } from '../context/reducer/buyingReducer';
+import { fetchKnowingPostList } from '../context/reducer/knowingReducer';
+
 export default function Search() {
+  const dispatch = useAppDispatch();
+  const [keyword, setKeyword] = useState<string>('');
+  const menuType = useAppSelector((state) => state.menu.menuType);
+  const [isKeyDown, setIsKeyDown] = useState(false);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.nativeEvent.isComposing && !isKeyDown) {
+      setIsKeyDown(true);
+      // 키워드가 없을 경우 전체 검색
+      if (keyword.length === 0) {
+        switch (menuType) {
+          case 'buying':
+            dispatch(fetchBuyingPostList());
+            break;
+          case 'knowing':
+            dispatch(fetchKnowingPostList());
+            break;
+        }
+      } else if (keyword.length > 1) {
+        switch (menuType) {
+          case 'buying':
+            dispatch(fetchBuyingPostList(keyword));
+            break;
+          case 'knowing':
+            dispatch(fetchKnowingPostList(keyword));
+            break;
+        }
+      } else alert('2자 이상부터 검색 가능합니다.');
+    }
+  };
+
+  const handleKeyUp = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      setIsKeyDown(false);
+    }
+  };
+
   return (
     <SearchLayout>
-      <SearchInputBox placeholder="검색어를 입력해주세요" />
+      <SearchInputBox
+        placeholder="검색어를 입력해주세요"
+        onChange={(e) => setKeyword(e.target.value)}
+        value={keyword}
+        onKeyDown={handleKeyDown}
+        onKeyUp={handleKeyUp}
+      />
       <SearchImg>
         <SearchIcon style={{ verticalAlign: 'middle' }} />
       </SearchImg>

--- a/src/context/reducer/buyingReducer.ts
+++ b/src/context/reducer/buyingReducer.ts
@@ -1,0 +1,45 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+
+import { getBuyingPostList } from '../../api/saving';
+
+export const fetchBuyingPostList = createAsyncThunk(
+  'user/fetchBuyingPostList',
+  async (keyword: string | undefined) => {
+    const res = await getBuyingPostList(keyword);
+    return res.data.detail.content;
+  },
+);
+
+interface buyingState {
+  data: buyingPostType[];
+  loading: boolean;
+  error: string | undefined | null;
+}
+
+const initialState: buyingState = {
+  data: [],
+  loading: false,
+  error: null,
+};
+
+const buyingSlice = createSlice({
+  name: 'buying',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchBuyingPostList.pending, (state) => {
+        state.loading = true;
+      })
+      .addCase(fetchBuyingPostList.fulfilled, (state, action) => {
+        state.loading = false;
+        state.data = action.payload;
+      })
+      .addCase(fetchBuyingPostList.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.error.message;
+      });
+  },
+});
+
+export default buyingSlice.reducer;

--- a/src/context/reducer/knowingReducer.ts
+++ b/src/context/reducer/knowingReducer.ts
@@ -1,0 +1,45 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+
+import { getKnowingPostList } from '../../api/saving';
+
+export const fetchKnowingPostList = createAsyncThunk(
+  'user/fetchKnowingPostList',
+  async (keyword: string | undefined) => {
+    const res = await getKnowingPostList(keyword);
+    return res.data.detail.content;
+  },
+);
+
+interface knowingState {
+  data: knowingPostType[];
+  loading: boolean;
+  error: string | undefined | null;
+}
+
+const initialState: knowingState = {
+  data: [],
+  loading: false,
+  error: null,
+};
+
+const knowingSlice = createSlice({
+  name: 'knowing',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchKnowingPostList.pending, (state) => {
+        state.loading = true;
+      })
+      .addCase(fetchKnowingPostList.fulfilled, (state, action) => {
+        state.loading = false;
+        state.data = action.payload;
+      })
+      .addCase(fetchKnowingPostList.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.error.message;
+      });
+  },
+});
+
+export default knowingSlice.reducer;

--- a/src/context/reducer/menuReducer.ts
+++ b/src/context/reducer/menuReducer.ts
@@ -1,0 +1,25 @@
+// 현재 페이지의 종류를 관리하는 리듀서
+// 아껴쓰기-같이사요: buying
+// 아껴쓰기-같이알아요: knowing
+import { createSlice } from '@reduxjs/toolkit';
+
+interface menuState {
+  menuType: string;
+}
+
+const initialState: menuState = {
+  menuType: '',
+};
+
+const menuSlice = createSlice({
+  name: 'menu',
+  initialState,
+  reducers: {
+    setMenuType: (state, action) => {
+      state.menuType = action.payload;
+    },
+  },
+});
+
+export const { setMenuType } = menuSlice.actions;
+export default menuSlice.reducer;

--- a/src/context/reducer/rootReducer.ts
+++ b/src/context/reducer/rootReducer.ts
@@ -6,8 +6,10 @@ import knowingEditReducer from './knowingEditReducer';
 import savingReducer from './savingReducer';
 import buyingReducer from './buyingReducer';
 import knowingReducer from './knowingReducer';
+import menuReducer from './menuReducer';
 
 const rootReducer = combineReducers({
+  menu: menuReducer,
   saving: savingReducer,
   buying: buyingReducer,
   buyingEdit: buyingEditReducer,

--- a/src/context/reducer/rootReducer.ts
+++ b/src/context/reducer/rootReducer.ts
@@ -4,10 +4,14 @@ import buyingEditReducer from './buyingEditReducer';
 import mapReducer from './mapReducer';
 import knowingEditReducer from './knowingEditReducer';
 import savingReducer from './savingReducer';
+import buyingReducer from './buyingReducer';
+import knowingReducer from './knowingReducer';
 
 const rootReducer = combineReducers({
   saving: savingReducer,
+  buying: buyingReducer,
   buyingEdit: buyingEditReducer,
+  knowing: knowingReducer,
   knowingEdit: knowingEditReducer,
   map: mapReducer,
 });

--- a/src/context/reducer/savingReducer.ts
+++ b/src/context/reducer/savingReducer.ts
@@ -1,12 +1,10 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 interface savingState {
-  isBuyingMenu: boolean;
   scroll: number;
 }
 
 const initialState: savingState = {
-  isBuyingMenu: true,
   scroll: 0,
 };
 
@@ -14,14 +12,11 @@ const savingSlice = createSlice({
   name: 'saving',
   initialState,
   reducers: {
-    setIsBuyingMenu: (state, action) => {
-      state.isBuyingMenu = action.payload;
-    },
     setScroll: (state, action) => {
       state.scroll = action.payload;
     },
   },
 });
 
-export const { setIsBuyingMenu, setScroll } = savingSlice.actions;
+export const { setScroll } = savingSlice.actions;
 export default savingSlice.reducer;

--- a/src/pages/Saving/SavingBoard.tsx
+++ b/src/pages/Saving/SavingBoard.tsx
@@ -13,14 +13,12 @@ import ContentKnowingItem from '../../components/Content/ContentKnowingItem';
 import { useAppDispatch, useAppSelector } from '../../hooks/redux';
 import { fetchBuyingPostList } from '../../context/reducer/buyingReducer';
 import { fetchKnowingPostList } from '../../context/reducer/knowingReducer';
-import {
-  setIsBuyingMenu,
-  setScroll,
-} from '../../context/reducer/savingReducer';
+import { setScroll } from '../../context/reducer/savingReducer';
+import { setMenuType } from '../../context/reducer/menuReducer';
 
 export default function SavingBoard() {
   const dispatch = useAppDispatch();
-  const isBuyingMenu = useAppSelector((state) => state.saving.isBuyingMenu);
+  const menuType = useAppSelector((state) => state.menu.menuType);
   const scroll = useAppSelector((state) => state.saving.scroll);
   const buyingPostList = useAppSelector((state) => state.buying.data);
   const knowingPostList = useAppSelector((state) => state.knowing.data);
@@ -32,6 +30,7 @@ export default function SavingBoard() {
   };
 
   useEffect(() => {
+    dispatch(setMenuType('buying'));
     window.addEventListener('scroll', handle);
     return () => {
       window.removeEventListener('scroll', handle);
@@ -39,12 +38,12 @@ export default function SavingBoard() {
   }, []);
 
   useEffect(() => {
-    if (isBuyingMenu) {
+    if (menuType === 'buying') {
       dispatch(fetchBuyingPostList());
     } else {
       dispatch(fetchKnowingPostList());
     }
-  }, [isBuyingMenu]);
+  }, [menuType]);
 
   useEffect(() => {
     // 게시글 목록 로드가 끝난뒤 저장된 이전 스크롤 수치를 적용
@@ -52,7 +51,7 @@ export default function SavingBoard() {
   }, [buyingPostList, knowingPostList]);
 
   const goWrite = () => {
-    isBuyingMenu
+    menuType === 'buying'
       ? navigate('/saving/buying/write')
       : navigate('/saving/knowing/write');
   };
@@ -60,17 +59,17 @@ export default function SavingBoard() {
   const handleClick = (whatMenu: string) => {
     // 현재 선택된 메뉴를 또 클릭시 smooth한 스크롤로 최상단 이동
     if (
-      (whatMenu === 'buying' && isBuyingMenu) ||
-      (whatMenu === 'knowing' && !isBuyingMenu)
+      (whatMenu === 'buying' && menuType === 'buying') ||
+      (whatMenu === 'knowing' && menuType === 'knowing')
     )
       window.scrollTo({ top: 0, behavior: 'smooth' });
     // 현재 선택되지 않은 메뉴를 클릭시 메뉴 전환 후 스크롤 최상단 이동
     // 전환후 최상단 스크롤 이동이 없을 경우 이전 메뉴의 스크롤이 전환 후 메뉴 스크롤에도 남게됨
     else if (whatMenu === 'buying') {
-      dispatch(setIsBuyingMenu(true));
+      dispatch(setMenuType('buying'));
       window.scrollTo({ top: 0 });
     } else {
-      dispatch(setIsBuyingMenu(false));
+      dispatch(setMenuType('knowing'));
       window.scrollTo({ top: 0 });
     }
   };
@@ -91,20 +90,20 @@ export default function SavingBoard() {
         <Search />
         <MenuCol
           onClick={() => handleClick('buying')}
-          isBuyingMenu={isBuyingMenu}
+          isBuyingMenu={menuType === 'buying'}
         >
           같이 사요
         </MenuCol>
         <MenuCol
           onClick={() => handleClick('knowing')}
-          isBuyingMenu={!isBuyingMenu}
+          isBuyingMenu={menuType === 'knowing'}
         >
           같이 알아요
         </MenuCol>
       </HeaderSection>
       <ContentSection>
         <ContentList>
-          {isBuyingMenu
+          {menuType === 'buying'
             ? buyingPostList.map((post) => (
                 <ContentBuyingItem
                   key={post.id}

--- a/src/pages/Saving/SavingBoard.tsx
+++ b/src/pages/Saving/SavingBoard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import MessageOutlinedIcon from '@mui/icons-material/MessageOutlined';
@@ -10,8 +10,9 @@ import Footer from '../../components/Footer';
 import HeaderRight from '../../components/Header/HeaderRight';
 import ContentBuyingItem from '../../components/Content/ContentBuyingItem';
 import ContentKnowingItem from '../../components/Content/ContentKnowingItem';
-import { getBuyingPostList, getKnowingPostList } from '../../api/saving';
 import { useAppDispatch, useAppSelector } from '../../hooks/redux';
+import { fetchBuyingPostList } from '../../context/reducer/buyingReducer';
+import { fetchKnowingPostList } from '../../context/reducer/knowingReducer';
 import {
   setIsBuyingMenu,
   setScroll,
@@ -21,8 +22,8 @@ export default function SavingBoard() {
   const dispatch = useAppDispatch();
   const isBuyingMenu = useAppSelector((state) => state.saving.isBuyingMenu);
   const scroll = useAppSelector((state) => state.saving.scroll);
-  const [buyingPostList, setBuyingPostList] = useState<buyingPostType[]>([]);
-  const [knowingPostList, setKnowingPostList] = useState<knowingPostType[]>([]);
+  const buyingPostList = useAppSelector((state) => state.buying.data);
+  const knowingPostList = useAppSelector((state) => state.knowing.data);
   const navigate = useNavigate();
 
   const handle = () => {
@@ -39,13 +40,9 @@ export default function SavingBoard() {
 
   useEffect(() => {
     if (isBuyingMenu) {
-      getBuyingPostList().then((res) => {
-        setBuyingPostList(res.data.detail.content);
-      });
+      dispatch(fetchBuyingPostList());
     } else {
-      getKnowingPostList().then((res) => {
-        setKnowingPostList(res.data.detail.content);
-      });
+      dispatch(fetchKnowingPostList());
     }
   }, [isBuyingMenu]);
 


### PR DESCRIPTION
### 변경이 필요한 배경
* Search.tsx 컴포넌트에서 검색 기능을 추가할때 게시글 목록을 요청을 하고 전달 받은 응답값을 멀리 떨어진 SavingBoard.tsx 페이지까지 전달하기 어려움
* Search.tsx 컴포넌트에서 현재 페이지 종류에 따라 검색 요청 API 가 달라짐

### 변경된 부분
* 아껴쓰기 게시글 API 요청을 전역 상태 관리자(Redux)를 통해 관리하도록 변경하여 어디서든(검색 컴포넌트) API를 요청할 수 있고 결과가 해당 상태를 사용하고 있는 모든 곳에서 일괄 변경될 수 있도록 변경
* 현재 페이지 종류를 나타내는 state(menuType)를 Redux로 분리하여 현재 페이지 타입이 무엇인지 모든 컴포넌트에서 쉽게 확인 가능

### 구현한 기능
* 현재 페이지 종류(아껴쓰기-같이사요, 아껴쓰기-같이알아요)에 따른 게시글 검색 기능